### PR TITLE
fix: syntax error: operand expected

### DIFF
--- a/src/usr/bin/clashctl.sh
+++ b/src/usr/bin/clashctl.sh
@@ -30,6 +30,10 @@ if [ -f $CLASH_CONFIG_ROOT/USE_PROXY ]; then
   [[ $USE_PROXY -lt 1 ]] && USE_PROXY=1
 fi
 
+if [ -z $USE_PROXY ]; then
+  USE_PROXY=0
+fi
+
 # Clash premium only support 1 single tun interface named utun.
 DEV=utun
 


### PR DESCRIPTION
`$USE_PROXY` may not be initialized correctly.